### PR TITLE
Normalisation implementation for 2D hists

### DIFF
--- a/config/CaloLayer2.json
+++ b/config/CaloLayer2.json
@@ -1,18 +1,27 @@
 {
   "main_gdir": "DQMData/Run {0}/L1T/Run summary/L1TStage2CaloLayer2/",
   "hists": [{
+      "norm_type": "total",
       "path": "Central-Jets/*"
     }, {
+      "norm_type": "total",
       "path": "Forward-Jets/*"
     }, {
+      "norm_type": "total",
       "path": "Isolated-EG/*"
     }, {
+      "norm_type": "total",
       "path": "Isolated-Tau/*"
     }, {
+      "norm_type": "total",
       "path": "NonIsolated-EG/*"
     }, {
+      "norm_type": "total",
       "path": "NonIsolated-Tau/*"
     }, {
+      "always_true": true,
+      "norm_type": "row",
+      "comparators": ["ks_test"],
       "path": "Energy-Sums/*"
     }
   ]


### PR DESCRIPTION
Adding a normalisation option for 2D hists that normalises both rows and columns. Currently does this across two modules, looking to reduce this to 1 with UpROOT upgrade, by norm_row, transpose, norm_row, transpose, for which this feature exists.